### PR TITLE
Needed space after period in sentence.

### DIFF
--- a/pcweb/pages/docs/hosting/self_hosting.py
+++ b/pcweb/pages/docs/hosting/self_hosting.py
@@ -104,7 +104,7 @@ def self_hosting():
         subheader("Pynecone Container Service"),
         doctext(
             "Another option is to run your Pynecone service in a container.",
-            "For this purpose, a ",
+            " For this purpose, a ",
             pc.code("Dockerfile"),
             " and additional documentation is available in the Pynecone project in the directory ",
             pc.code("docker-example"),

--- a/pcweb/pages/docs/hosting/self_hosting.py
+++ b/pcweb/pages/docs/hosting/self_hosting.py
@@ -103,8 +103,8 @@ def self_hosting():
         ),
         subheader("Pynecone Container Service"),
         doctext(
-            "Another option is to run your Pynecone service in a container.",
-            " For this purpose, a ",
+            "Another option is to run your Pynecone service in a container. ",
+            "For this purpose, a ",
             pc.code("Dockerfile"),
             " and additional documentation is available in the Pynecone project in the directory ",
             pc.code("docker-example"),


### PR DESCRIPTION
Added a space after the period in this line, ... Another option is to run your Pynecone service in a container. 

So that there is a space between the two sentences. =)

Altered my original commit per r0b2g1t's request.