### PR TITLE
Datatable docs modification:

### DIFF
--- a/pcweb/pages/docs/component.py
+++ b/pcweb/pages/docs/component.py
@@ -42,7 +42,7 @@ class Source(Base):
         # Get the source code.
         self.code = [
             line
-            for line in inspect.getsource(self.component).split("\n")
+            for line in inspect.getsource(self.component).splitlines()
             if len(line) > 0
         ]
 
@@ -119,7 +119,7 @@ class Source(Base):
 
     @staticmethod
     def get_comment(comments: list[str]):
-        return "\n".join([comment.strip().strip("#") for comment in comments])
+        return "".join([comment.strip().strip("#") for comment in comments])
 
 
 # Mapping from types to colors.

--- a/pcweb/pages/docs/component_lib/datadisplay.py
+++ b/pcweb/pages/docs/component_lib/datadisplay.py
@@ -203,6 +203,22 @@ pc.data_table(
 )           
 """
 
+datatable_example_3 = """class State(pc.State):
+    data: List = [
+        ["Lionel", "Messi", "PSG"],
+        ["Christiano", "Ronaldo", "Al-Nasir"]
+     ]
+    columns: List[str] = ["First Name", "Last Name"]
+    
+    def index():  
+        return pc.data_table(
+        data =State.data,
+        columns=State.columns,
+        )   
+
+    
+    """
+
 
 def render_datatable():
     return pc.vstack(
@@ -230,7 +246,6 @@ def render_datatable():
                     ["Marcus Smart", "6-4", 22.0],
                 ],
                 columns=["Name", "Height", "Age"],
-                # data=nba_data()[["Name", "Height", "Age"]],
                 pagination=True,
                 search=True,
                 sort=True,
@@ -239,6 +254,8 @@ def render_datatable():
         ),
         doccode(datatable_example_2_df),
         doccode(datatable_example_2_table),
+        doctext("The example below shows how to create a data table from from a list."),
+        doccode(datatable_example_3),
         align_items="start",
     )
 


### PR DESCRIPTION
This PR adds the following changes:
- Fixes assertion error when ran on windows due to the inspect module using `\n` for linesep whereas its `\r\n` for windows.
- Picks up prop comments that span multiple line. Previously, only the line above the prop was used.
- Added more examples to datatable component docs.