### PR TITLE
Update the document to match the version in PR #957 of pynecone

### DIFF
--- a/pcweb/pages/docs/getting_started/installation.py
+++ b/pcweb/pages/docs/getting_started/installation.py
@@ -25,7 +25,7 @@ def installation():
         pc.unordered_list(
             pc.list_item("Python 3.7+"),
             pc.list_item(
-                doclink("NodeJS 12.22.0+", href=constants.NODEJS_URL),
+                doclink("NodeJS 16.6.0+", href=constants.NODEJS_URL),
             ),
             padding_left="2em",
         ),


### PR DESCRIPTION
## Update the document to match the version in PR #957 on [pynecone-io/pynecone.](https://github.com/pynecone-io/pynecone)
### Change the document to match the following PR
The reason why we use node 16.6.0 is because of nba example.
And the detail information is described in the following PR. 
- https://github.com/pynecone-io/pynecone/pull/957