### PR TITLE
Update min node version in docs for the released pc 0.1.30

### DIFF
--- a/pcweb/pages/docs/getting_started/installation.py
+++ b/pcweb/pages/docs/getting_started/installation.py
@@ -25,7 +25,7 @@ def installation():
         pc.unordered_list(
             pc.list_item("Python 3.7+"),
             pc.list_item(
-                doclink("NodeJS 16.6.0+", href=constants.NODEJS_URL),
+                doclink("NodeJS 16.8.0+", href=constants.NODEJS_URL),
             ),
             padding_left="2em",
         ),


### PR DESCRIPTION
Update the document to match the version in PR #1041 on
[pynecone-io/pynecone.](https://github.com/pynecone-io/pynecone)

Change the document to match the following PR
We can use node 16.6.0 to create default project of pynecone==0.1.29
But we cannot use node 16.6.0  to create default project of pynecone==0.1.30 
After testing, we need to set up min node version 16.8.0 for pynecone==0.1.30  

And the detail information is described in the following PR.

- https://github.com/pynecone-io/pynecone/pull/1041 
