### PR TITLE
[Fix issue 80] ensure pcweb's installation correctly 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 email-validator==1.3.0
-black==22.6.0
-pandas==1.5.0
+black==22.12.0
+pandas==1.5.3
 psycopg2-binary==2.9.5
 plotly-express==0.4.1
 googletrans-py==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 email-validator==1.3.0
 black==22.6.0
 pandas==1.5.0
-psycopg2==2.9.5
+psycopg2-binary==2.9.5
 plotly-express==0.4.1
 googletrans==3.1.0a0
 typesense==0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ black==22.6.0
 pandas==1.5.0
 psycopg2-binary==2.9.5
 plotly-express==0.4.1
-googletrans==3.1.0a0
+googletrans-py==4.0.0
 typesense==0.14.0
 


### PR DESCRIPTION

Solve issue 80 
* psycopg2 -> psycopg2-binary
* googletrans -> googletrans-py 4.0.0
The detail description is put in the content of issue
- https://github.com/pynecone-io/pcweb/issues/80