### PR TITLE
Lendemor/fix middleware page

### DIFF
--- a/pcweb/components/sidebar.py
+++ b/pcweb/components/sidebar.py
@@ -132,7 +132,7 @@ def get_sidebar_items_learn():
                 advanced_guide.memoization,
                 advanced_guide.wrapping_react,
                 advanced_guide.api_routes,
-                advanced_guide.middleware,
+                advanced_guide.use_middleware,
                 advanced_guide.telemetry,
             ],
         )

--- a/pcweb/pages/docs/advanced_guide/__init__.py
+++ b/pcweb/pages/docs/advanced_guide/__init__.py
@@ -1,6 +1,6 @@
 from .custom_vars import custom_vars
 from .memoization import memoization
-from .middleware import use_middleware
+from .use_middleware import use_middleware
 from .wrapping_react import wrapping_react
 from .api_routes import api_routes
 from .telemetry import telemetry

--- a/pcweb/pages/docs/advanced_guide/__init__.py
+++ b/pcweb/pages/docs/advanced_guide/__init__.py
@@ -1,6 +1,6 @@
 from .custom_vars import custom_vars
 from .memoization import memoization
-from .middleware import middleware
+from .middleware import use_middleware
 from .wrapping_react import wrapping_react
 from .api_routes import api_routes
 from .telemetry import telemetry

--- a/pcweb/pages/docs/advanced_guide/use_middleware.py
+++ b/pcweb/pages/docs/advanced_guide/use_middleware.py
@@ -4,7 +4,7 @@ from pcweb.templates.docpage import doccode, docheader, docpage, doctext, subhea
 
 
 @docpage()
-def middleware():
+def use_middleware():
     from pcweb.pages.docs.components.overview import components_overview
     from pcweb.pages.docs.styling.overview import styling_overview
 

--- a/pcweb/pages/docs/component_lib/feedback.py
+++ b/pcweb/pages/docs/component_lib/feedback.py
@@ -51,6 +51,7 @@ code37 = """pc.vstack(
 )
 """
 
+
 # Feedback
 def render_alert():
     return pc.vstack(

--- a/pcweb/pages/docs/component_lib/media.py
+++ b/pcweb/pages/docs/component_lib/media.py
@@ -38,6 +38,8 @@ code82 = """pc.avatar_group(
     max_=3,
 )
 """
+
+
 # Media
 def render_avatar():
     return pc.box(

--- a/pcweb/pages/docs/component_lib/navigation.py
+++ b/pcweb/pages/docs/component_lib/navigation.py
@@ -19,6 +19,7 @@ breadcrumb_separator = """pc.breadcrumb(
 )
 """
 
+
 # Navigation
 def render_breadcrumb():
     return pc.vstack(

--- a/scripts/search_index.py
+++ b/scripts/search_index.py
@@ -4,6 +4,7 @@ from pcweb.pages.docs.component import multi_docs
 from pcweb.tsclient import client
 from pynecone.components.base.bare import Bare
 
+
 def get_strings(comp):
     """Get the strings from a component."""
     strings = []
@@ -16,7 +17,10 @@ def get_strings(comp):
             strings += get_strings(child)
     return strings
 
+
 from collections import defaultdict
+
+
 def get_text(comp, href):
     """Get the text from a component."""
     text = []
@@ -28,6 +32,7 @@ def get_text(comp, href):
         else:
             text += get_text(child, href)
     return text
+
 
 def postprocess(texts):
     headings = defaultdict(list)
@@ -44,7 +49,10 @@ def postprocess(texts):
             del headings[("Base Events Triggers", href)]
     # del headings["Base Event Triggers"]
     dud = "Site Documentation Resources Copyright © 2023 Pynecone"
-    return {key: " ".join(value).replace("  ", " ").replace(dud, "") for key, value in headings.items()}
+    return {
+        key: " ".join(value).replace("  ", " ").replace(dud, "")
+        for key, value in headings.items()
+    }
 
 
 class Doc(pc.Base):
@@ -52,11 +60,13 @@ class Doc(pc.Base):
     description: str
     href: str
 
+
 out = {}
 from pcweb.component_list import component_list
+
 for key in component_list:
     for component_group in component_list[key]:
-        path =  f"/docs/library/{key.lower()}/{component_group[0].__name__.lower()}"
+        path = f"/docs/library/{key.lower()}/{component_group[0].__name__.lower()}"
         comp = multi_docs(path=path, component_list=component_group).component()
         texts = get_text(comp, path)
         out |= postprocess(texts)
@@ -72,18 +82,20 @@ import sys
 import typesense
 
 try:
-    client.collections['search-auto'].delete()
+    client.collections["search-auto"].delete()
 except Exception as e:
     pass
 
-create_response = client.collections.create({
-    "name": "search-auto",
-    "fields": [
-        {"name": "heading", "type": "string"},
-        {"name": "description", "type": "string"},
-        {"name": "href", "type": "string"},
-    ],
-})
+create_response = client.collections.create(
+    {
+        "name": "search-auto",
+        "fields": [
+            {"name": "heading", "type": "string"},
+            {"name": "description", "type": "string"},
+            {"name": "href", "type": "string"},
+        ],
+    }
+)
 
 
 docs = []
@@ -92,4 +104,4 @@ for key, text in out.items():
 
 for doc in docs:
     print(doc)
-    client.collections['search-auto'].documents.create(doc)
+    client.collections["search-auto"].documents.create(doc)


### PR DESCRIPTION
Temporary fix to resolve the conflict between `advanced-guide/middleware` and `api-reference/middleware`

Change the former to `advanced-guide/use-middleware` instead.

Can be rolled back once we find the proper fix to avoid name conflict when building pages.