### PR TITLE
Type annotation:

### DIFF
--- a/pcweb/pages/docs/state/events.py
+++ b/pcweb/pages/docs/state/events.py
@@ -258,6 +258,19 @@ def events():
             pc.code("change_color"),
             " event handler with the text and the index of the input.",
         ),
+        doctext(
+            pc.alert(
+                pc.alert_icon(),
+                pc.box(
+                    pc.alert_title("Event Handler Parameters must provide type annotations."),
+                    pc.alert_description(
+                        "Like state vars, be sure to provide the right type annotations for the prameters in an event "
+                        "handler."
+                    ),
+                ),
+                status="warning",
+            ),
+        ),
         subheader("Setters"),
         doctext(
             "Every base var has a built-in event handler to set it's value for convenience, called",

--- a/pcweb/pages/docs/state/vars.py
+++ b/pcweb/pages/docs/state/vars.py
@@ -208,4 +208,19 @@ def index():
             "Backend vars are prefixed with an underscore. ",
         ),
         docdemo(code10, code9, eval(code10), context=True),
+        doctext(
+            pc.alert(
+                pc.alert_icon(),
+                pc.box(
+                    pc.alert_title("State Vars must provide type annotations."),
+                    pc.alert_description(
+                        "Pynecone relies on type annotations to determine the type of state vars during the "
+                        "compilation process.",
+                        " Therefore, all state vars should be annotated correctly.",
+                        ".",
+                    ),
+                ),
+                status="warning",
+            ),
+        ),
     )


### PR DESCRIPTION
Type annotation warning for vars and event handlers