### PR TITLE
Fixed minor typo in Custom Stylesheets

### DIFF
--- a/pcweb/pages/docs/styling/custom_stylesheets.py
+++ b/pcweb/pages/docs/styling/custom_stylesheets.py
@@ -100,7 +100,7 @@ def custom_stylesheets():
         doccode(
             """app = pc.App(
             stylesheets=[
-                "font/myfont.css",  # This path is relative to assets/
+                "fonts/myfont.css",  # This path is relative to assets/
             ],
         )"""
         ),


### PR DESCRIPTION
Hello everyone,

I have fixed a small typo I noticed in the Custom Stylesheets section of the website. 

<img width="791" alt="Screenshot 2023-06-17 at 10 49 06" src="https://github.com/pynecone-io/pcweb/assets/71128266/f0623719-89ff-41e7-bd42-8ade3978c518">

It should be `"fonts/myfont.css"`.

Best,
Divin

PS: First time contributing to an open source project, so please let me know if I did anything wrong 😄 